### PR TITLE
fix what looks to be a copy-paste error or typo, caused pickle error

### DIFF
--- a/Orange/ensemble/stacking.py
+++ b/Orange/ensemble/stacking.py
@@ -46,7 +46,7 @@ class StackedClassificationLearner(Orange.classification.Learner):
         return StackedClassifier(classifiers, meta_classifier, name=self.name)
 
     def __reduce__(self):
-        return type(self), (self.learner,), dict(self.__dict__)
+        return type(self), (self.learners,), dict(self.__dict__)
 
 
 class StackedClassifier:


### PR DESCRIPTION
I ran across this issue while working on a classification script. Seems simple enough but I don't have much background with the code-base. What do you think?
