### PR TITLE
Strip unix and windows line breaks from end of arff lines

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -131,7 +131,7 @@ def loadARFF_Weka(filename, create_on_new=MakeStatus.Incompatible, **kwargs):
     state = 0 # header
     data = []
     for l in f.readlines():
-        l = l.rstrip("\n") # strip \n
+        l = l.rstrip("\n\r") # strip trailing whitespace
         l = l.replace('\t', ' ') # get rid of tabs
         x = l.split('%')[0] # strip comments
         if len(x.strip()) == 0:


### PR DESCRIPTION
I was given an arff file and Orange failed to load all data instance from it.  It turns out the arff had window line endings and orange did not recognize the `@data` line because it only stripped trailing `\n` characters.  Changed the arff loader to strip trailing `\r` as well as `\n` so it can successfully parse files with this problem.