### PR TITLE
Use https to query pypi API

### DIFF
--- a/Orange/utils/addons.py
+++ b/Orange/utils/addons.py
@@ -132,7 +132,8 @@ def search_index(query):
 
 
 def refresh_available_addons(force=False, progress_callback=None):
-    pypi = xmlrpclib.ServerProxy('http://pypi.python.org/pypi')
+    pypi = xmlrpclib.ServerProxy('https://pypi.python.org/pypi',
+                                 transport=xmlrpclib.SafeTransport())
     if progress_callback:
         progress_callback(1, 0)
 


### PR DESCRIPTION
The API is no longer accessible over plain http:

    https://mail.python.org/pipermail/distutils-sig/2016-June/029125.html